### PR TITLE
4/28 HeartHubs updates

### DIFF
--- a/sites/hearthubs.org/config/navigation.js
+++ b/sites/hearthubs.org/config/navigation.js
@@ -17,7 +17,7 @@ const conferences = [
 ];
 
 const vascularTopics = [
-  { href: '/vascular/2020-program', label: '2020 Program' },
+  { href: '/vascular/2020-program', label: '2020 Schedule' },
   { href: '/vascular/exhibitors', label: 'Exhibits' },
   { href: 'https://professional.heart.org/professional/EducationMeetings/MeetingsLiveCME/ATVBPVD/UCM_506015_Science-News-for-Vascular-Discovery-2020.jsp', label: 'Science News', target: '_blank' },
   { href: 'https://www.ahajournals.org/vascular-discovery', label: 'Journals', target: '_blank' },
@@ -27,7 +27,7 @@ const vascularTopics = [
 
 const qcorTopics = [
   { href: '/qcor/science-news', label: 'Science News' },
-  { href: '/qcor/2020-program', label: '2020 Program' },
+  { href: '/qcor/2020-program', label: '2020 Schedule' },
   { href: '/qcor/learning-studios', label: 'Learning Studios' },
 ];
 

--- a/sites/hearthubs.org/server/components/blocks/event-schedule.marko
+++ b/sites/hearthubs.org/server/components/blocks/event-schedule.marko
@@ -57,7 +57,7 @@ $ const displayEventDay = defaultValue(input.displayEventDay, true);
               <div class=`${blockName}__content-event-times`>
                 <marko-web-content-start-date tag="span" format="h:mm a" block-name=blockName obj=content />
                 <marko-web-content-end-date tag="span" format="h:mm a" block-name=blockName obj=content />
-                <span> (Central) </span>
+                <span> (CST) </span>
                 <marko-web-content-start-date tag="span" format="MMM D, YYYY" block-name=blockName obj=content />
               </div>
             </@text>

--- a/sites/hearthubs.org/server/components/blocks/featured-exhibitors-full.marko
+++ b/sites/hearthubs.org/server/components/blocks/featured-exhibitors-full.marko
@@ -15,8 +15,8 @@ $ const queryParams = {
 };
 
 <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
-  $ const shuffled = shuffle(nodes);
-  <default-theme-card-deck-flow cols=2 nodes=shuffled>
+  <!-- $ const shuffled = shuffle(nodes); -->
+  <default-theme-card-deck-flow cols=2 nodes=nodes>
     <@slot|{ node: content }|>
       $ const primaryImage = getAsObject(content, "primaryImage");
       <marko-web-node

--- a/sites/hearthubs.org/server/components/blocks/featured-exhibitors.marko
+++ b/sites/hearthubs.org/server/components/blocks/featured-exhibitors.marko
@@ -15,13 +15,13 @@ $ const queryParams = {
 };
 
 <marko-web-query|{ nodes }| name="website-scheduled-content" params=queryParams>
-  $ const shuffled = shuffle(nodes);
+  <!-- $ const shuffled = shuffle(nodes); -->
   <marko-web-node-list>
     <@header>
       Industry Participants
     </@header>
-    <@nodes nodes=shuffled>
-      <default-theme-card-deck-flow cols=4 nodes=shuffled modifiers=["featured-exhibitors"]>
+    <@nodes nodes=nodes>
+      <default-theme-card-deck-flow cols=4 nodes=nodes modifiers=["featured-exhibitors"]>
         <@slot|{ node: content }|>
           $ const primaryImage = getAsObject(content, "primaryImage");
           <marko-web-node

--- a/sites/hearthubs.org/server/components/blocks/global-right-rail.marko
+++ b/sites/hearthubs.org/server/components/blocks/global-right-rail.marko
@@ -18,5 +18,5 @@ $ const { aliases } = input;
   collapse-before-ad-fetch=true
 />
 
-<a class="twitter-timeline" data-height="650" data-theme="light" href="https://twitter.com/AHAScience?ref_src=twsrc%5Etfw">Tweets by AHAScience</a>
+<a class="twitter-timeline" data-height="650" data-theme="light" href="https://twitter.com/AHAmeetings?ref_src=twsrc%5Etfw">Tweets by AHAScience</a>
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/sites/hearthubs.org/server/templates/content/index.marko
+++ b/sites/hearthubs.org/server/templates/content/index.marko
@@ -63,7 +63,7 @@ $ const displayPhotoswipe = ["contact"].includes(type) ? false : true;
                     <div class=`${blockName}__content-event-times`>
                       <marko-web-content-start-date tag="span" format="h:mm a" block-name=blockName obj=content />
                       <marko-web-content-end-date tag="span" format="h:mm a" block-name=blockName obj=content />
-                      <span> (Central) </span>
+                      <span> (CST) </span>
                       <marko-web-content-start-date tag="span" format="MMM D, YYYY" block-name=blockName obj=content />
                     </div>
                   </if>


### PR DESCRIPTION
- Update Twitter feed url
- Disable shuffling of exhibitors
- Rename "2020 Program" to "2020 Schedule"
- Update "Central" to "CST"