### PR TITLE
Hide global right rail if RMI is displayed

### DIFF
--- a/sites/hearthubs.org/server/templates/content/index.marko
+++ b/sites/hearthubs.org/server/templates/content/index.marko
@@ -169,8 +169,9 @@ $ const displayPhotoswipe = ["contact"].includes(type) ? false : true;
                   </@body>
                 </marko-web-node-list>
               </if>
-
-              <website-global-right-rail-block aliases=aliases no-shadow=true />
+              <else>
+                <website-global-right-rail-block aliases=aliases no-shadow=true />
+              </else>
             </aside>
 
             <if(displayPhotoswipe)>


### PR DESCRIPTION
Fixes overlay issue: https://www.hearthubs.org/vascular/exhibitors/video/21130252/fujifilm-visualsonics-inc-learn-from-our-experts-at-your-own-pace

