### PR TITLE
Add exhibitors banner block to hypertension

### DIFF
--- a/sites/hypertension.hub.heart.org/config/blocks.js
+++ b/sites/hypertension.hub.heart.org/config/blocks.js
@@ -24,4 +24,8 @@ module.exports = {
   'science-news': {
     href: 'https://professional.heart.org/en/meetings/hypertension/science-news-from-hypertension-2020',
   },
+  'exhibitors-banner': {
+    src: 'https://p1-cms-assets-ascend.imgix.net/files/base/ascend/hearthub/image/static/hypertension-exhibitors-banner.png',
+    href: '/exhibitors',
+  },
 };

--- a/sites/hypertension.hub.heart.org/server/templates/index.marko
+++ b/sites/hypertension.hub.heart.org/server/templates/index.marko
@@ -39,6 +39,8 @@ $ const {
 
           <shared-science-news-block queryParams={ sectionAlias: "science-news" } class="mb-block-lg" />
 
+          <shared-exhibitors-banner-block />
+
           <shared-content-featured-block section-alias="featured" link-header=false />
         </div>
 


### PR DESCRIPTION
<img width="1294" alt="Screen Shot 2020-09-02 at 10 50 49 AM" src="https://user-images.githubusercontent.com/2855198/92006606-8ed4fb80-ed0a-11ea-9cb0-6a66dffa1344.png">
